### PR TITLE
add: open route file with correct extension

### DIFF
--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -265,6 +265,16 @@ export const tryReadFilePath = async (filePath: string | vscode.Uri) => {
   }
 };
 
+export const isTSConfigExists = async (rootDir: vscode.Uri) => {
+  try {
+    const tsconfigPath = vscode.Uri.joinPath(rootDir, "tsconfig.json");
+    const content = await tryReadFile(tsconfigPath);
+    return content !== null;
+  } catch {
+    return false;
+  }
+};
+
 /**
  * Adds imports to a provided import statement by modifing the existing file content
  * @param importStatement Import statement to add to (can be a partial)


### PR DESCRIPTION
Use root `tsconfig.json` to detect whether the project is a TypeScript
project or not, based on that open `.tsx` or `.jsx` when receiving
`open-vscode` message.
