### PR TITLE
fix to execute `npx shadcn@latest` command

### DIFF
--- a/src/auth/authFiles/env.ts
+++ b/src/auth/authFiles/env.ts
@@ -3,8 +3,8 @@ import { AUTH_STRATEGY_OPTION } from "../config/options";
 export const generateEnvVars = (options: AUTH_STRATEGY_OPTION[], existingEnv: string) => {
   const envVars = options
     .map((option) => {
-      if (option.key === "form") return "";
-      if (existingEnv.includes(option.key.toUpperCase())) return "";
+      if (option.key === "form") {return "";}
+      if (existingEnv.includes(option.key.toUpperCase())) {return "";}
       const keys = [
         `# ${option.key} Env Variables`,
         `${option.key.toUpperCase()}_CLIENT_ID=""`,
@@ -30,6 +30,6 @@ export const generateEnvVars = (options: AUTH_STRATEGY_OPTION[], existingEnv: st
     finalOutput.push('SESSION_SECRET="s3cr3t"');
   }
   finalOutput.push(envVars);
-  if (finalOutput.length <= 2) return "";
+  if (finalOutput.length <= 2) {return "";}
   return finalOutput.join("\n");
 };

--- a/src/commands/barrelize.ts
+++ b/src/commands/barrelize.ts
@@ -18,11 +18,11 @@ const createBarrel = async (path: string, config: vscode.WorkspaceConfiguration)
   const barrelizeIndexExtension = config.get<string>("barrelizeIndexExtension") || "ts";
 
   for (const [file, fileType] of files) {
-    if (ignoreFiles.some((fileName) => file.includes(fileName))) continue;
+    if (ignoreFiles.some((fileName) => file.includes(fileName))) {continue;}
     const filePath = vscode.Uri.joinPath(vscode.Uri.file(path), file);
     const shouldRemoveExtension = removeExtensions.some((ext) => file.includes(ext));
     const finalFileName = shouldRemoveExtension ? file.split(".").slice(0, -1).join(".") : file;
-    if (!finalFileName) continue;
+    if (!finalFileName) {continue;}
     exports.push(`export * from "./${finalFileName}";`);
     // Generate the barrel for the subdirectory
     if (fileType === vscode.FileType.Directory) {

--- a/src/commands/devTools.ts
+++ b/src/commands/devTools.ts
@@ -29,7 +29,7 @@ export const startDevTools = async (statusBarItem: vscode.StatusBarItem) => {
   wss = new WebSocketServer({ port: port || 3003 });
   setStatusBarToRunning(statusBarItem);
 
-  const rootDir = getRootDir();
+  const rootDir = await getRootDir();
   if (!rootDir) {
     return undefined;
   }

--- a/src/commands/generateAuth.ts
+++ b/src/commands/generateAuth.ts
@@ -24,7 +24,7 @@ export const generateAuth = async (uri: vscode.Uri) => {
     title: "Select the strategies you want in your authentication workflow",
   });
 
-  if (!options) return;
+  if (!options) {return;}
 
   const servicesFolder = vscode.Uri.joinPath(uri, "services");
   const config = getConfig();

--- a/src/commands/generateAuth.ts
+++ b/src/commands/generateAuth.ts
@@ -12,8 +12,13 @@ import { generateEnvVars } from "../auth/authFiles/env";
 import { dashboardFileContent } from "../auth/authFiles/dashboard";
 import { getConfig } from "../config";
 import { askInstallDependenciesPrompt, joinPath, writeToFile } from "../utils/vscode";
+import { getRemixRootFromFileUri } from "../utils/file";
 
 export const generateAuth = async (uri: vscode.Uri) => {
+  const rootDir = await getRemixRootFromFileUri(uri);
+  if (!rootDir) {
+    return;
+  }
   const options = await vscode.window.showQuickPick<AUTH_STRATEGY_OPTION>(AUTH_OPTIONS, {
     canPickMany: true,
     title: "Select the strategies you want in your authentication workflow",
@@ -29,9 +34,7 @@ export const generateAuth = async (uri: vscode.Uri) => {
   const strategyFolder = vscode.Uri.joinPath(servicesFolder, "auth_strategies");
   await vscode.workspace.fs.createDirectory(strategyFolder);
 
-  const projectRoot = vscode.workspace.getWorkspaceFolder(uri);
-  const projectRootUri = projectRoot?.uri;
-  const envFile = vscode.Uri.joinPath(projectRootUri!, ".env");
+  const envFile = vscode.Uri.joinPath(rootDir!, ".env");
   let envFileContent: string | Uint8Array = "";
   try {
     envFileContent = await vscode.workspace.fs.readFile(envFile);
@@ -45,7 +48,7 @@ export const generateAuth = async (uri: vscode.Uri) => {
   const dashboardFile = vscode.Uri.joinPath(routesFolder, "dashboard.tsx");
   await vscode.workspace.fs.writeFile(
     envFile,
-    Buffer.from([envFileContent, generateEnvVars(options, envFileContent.toString())].join("\n"))
+    Buffer.from([envFileContent, generateEnvVars(options, envFileContent.toString())].join("\n")),
   );
   await vscode.workspace.fs.writeFile(authRouteFile, Buffer.from(authRouteFileContent(config), "utf8"));
   await vscode.workspace.fs.writeFile(dashboardFile, Buffer.from(dashboardFileContent(config), "utf8"));
@@ -95,5 +98,5 @@ export const generateAuth = async (uri: vscode.Uri) => {
       strategyDeps.push("remix-auth-auth0");
     }
   }
-  await askInstallDependenciesPrompt(["remix-auth", ...strategyDeps]);
+  await askInstallDependenciesPrompt(rootDir, ["remix-auth", ...strategyDeps]);
 };

--- a/src/commands/generateAuthSnippet.ts
+++ b/src/commands/generateAuthSnippet.ts
@@ -25,7 +25,11 @@ export const generateAuthSnippet = async (uri: vscode.Uri, type: "action" | "loa
       if (!line.includes("async")) {
         lineOutput = lineOutput.replace("=", `= async`);
       }
-      if (!line.includes("LoaderFunctionArgs") && !line.includes("ActionFunctionArgs") && !line.includes("DataFunctionArgs")) {
+      if (
+        !line.includes("LoaderFunctionArgs") &&
+        !line.includes("ActionFunctionArgs") &&
+        !line.includes("DataFunctionArgs")
+      ) {
         shouldAddTypeImport = true;
       }
 
@@ -40,7 +44,7 @@ export const generateAuthSnippet = async (uri: vscode.Uri, type: "action" | "loa
 
         lineOutput = lineOutput.replace(
           "=> {",
-          '=> {\n  await authenticator.isAuthenticated(request, { failureRedirect: "/login" });\n'
+          '=> {\n  await authenticator.isAuthenticated(request, { failureRedirect: "/login" });\n',
         );
 
         lineOutput = lineOutput + "\n}";
@@ -48,7 +52,7 @@ export const generateAuthSnippet = async (uri: vscode.Uri, type: "action" | "loa
       if (line.includes("=> {")) {
         lineOutput = lineOutput.replace(
           "=> {",
-          '=> {\n  await authenticator.isAuthenticated(request, { failureRedirect: "/login" });\n'
+          '=> {\n  await authenticator.isAuthenticated(request, { failureRedirect: "/login" });\n',
         );
       }
     }

--- a/src/commands/generateFormRouteFile.ts
+++ b/src/commands/generateFormRouteFile.ts
@@ -2,8 +2,13 @@ import * as vscode from "vscode";
 import { getConfig } from "../config";
 import { generateConformForm, generateRemixHookForm } from "../forms";
 import { askInstallDependenciesPrompt } from "../utils/vscode";
+import { getRemixRootFromFileUri } from "../utils/file";
 
 export const generateRemixFormRoute = async (uri: vscode.Uri) => {
+  const rootDir = await getRemixRootFromFileUri(uri);
+  if (!rootDir) {
+    return;
+  }
   const config = getConfig();
   const template = config.get<string>("formRouteTemplate");
 
@@ -25,11 +30,12 @@ export const generateRemixFormRoute = async (uri: vscode.Uri) => {
 
   await vscode.workspace.fs.writeFile(
     filePath,
-    Buffer.from(formHandler === "remix-hook-form" ? generateRemixHookForm() : generateConformForm())
+    Buffer.from(formHandler === "remix-hook-form" ? generateRemixHookForm() : generateConformForm()),
   );
   await askInstallDependenciesPrompt(
+    rootDir,
     formHandler === "remix-hook-form"
       ? ["react-hook-form", "remix-hook-form", "@remix-run/react", "@hookform/resolvers", "zod"]
-      : ["@conform-to/react", "@conform-to/zod", "@remix-run/react", "zod"]
+      : ["@conform-to/react", "@conform-to/zod", "@remix-run/react", "zod"],
   );
 };

--- a/src/commands/generatePrisma.ts
+++ b/src/commands/generatePrisma.ts
@@ -29,12 +29,12 @@ export const DB_SOURCE_OPTIONS: DB_SOURCE_OPTION[] = [
 
 export const generatePrisma = async (uri: vscode.Uri) => {
   const rootDir = await getRemixRootFromFileUri(uri);
-  if (!rootDir) return;
+  if (!rootDir) {return;}
 
   const prismaFolder = vscode.Uri.joinPath(rootDir, "prisma");
   const option = await vscode.window.showQuickPick(DB_SOURCE_OPTIONS);
 
-  if (!option) return;
+  if (!option) {return;}
 
   await runCommand({
     rootDir: rootDir,

--- a/src/commands/generateShadcnUI.ts
+++ b/src/commands/generateShadcnUI.ts
@@ -7,7 +7,7 @@ import {
   tryReadDirectory,
   writeToFile,
 } from "../utils/vscode";
-import { getRootDir, tryReadFile } from "../utils/file";
+import { getRemixRootFromFileUri, tryReadFile } from "../utils/file";
 import { getConfig, updateConfig } from "../config";
 
 const availableComponentList = [
@@ -67,8 +67,8 @@ const getAvailableComponents = async (rootDirPath: vscode.Uri, outputLocation: s
   return filteredComponents;
 };
 
-export const generateShadcnUI = async () => {
-  const rootDir = await getRootDir();
+export const generateShadcnUI = async (uri: vscode.Uri) => {
+  const rootDir = await getRemixRootFromFileUri(uri);
   if (!rootDir) {
     return;
   }
@@ -106,6 +106,7 @@ export const generateShadcnUI = async () => {
   const componentsToGenerate = pickedComponents.map((component) => component.key).join(" ");
 
   await runCommandWithPrompt({
+    rootDir,
     command: `npx shadcn-ui@latest add ${componentsToGenerate}`,
     title: "Generating shadcn/ui components",
     promptHandler: async (process, resolve) => {

--- a/src/commands/generateShadcnUI.ts
+++ b/src/commands/generateShadcnUI.ts
@@ -1,14 +1,13 @@
 import * as vscode from "vscode";
 import {
   getMultiplePickableOptions,
-  getUserInput,
   joinPath,
   runCommandWithPrompt,
   sanitizePath,
   tryReadDirectory,
   writeToFile,
 } from "../utils/vscode";
-import { getRootDir, getRootDirPath, tryReadFile } from "../utils/file";
+import { getRootDir, tryReadFile } from "../utils/file";
 import { getConfig, updateConfig } from "../config";
 
 const availableComponentList = [
@@ -69,14 +68,14 @@ const getAvailableComponents = async (rootDirPath: vscode.Uri, outputLocation: s
 };
 
 export const generateShadcnUI = async () => {
-  const rootDir = getRootDir();
+  const rootDir = await getRootDir();
   if (!rootDir) {
     return;
   }
   const initialized = await tryReadFile(joinPath(rootDir, "components.json"));
   if (!initialized) {
     vscode.window.showErrorMessage(
-      "Shadcn UI is not initialized in this project. (components.json declaration missing)"
+      "Shadcn UI is not initialized in this project. (components.json declaration missing)",
     );
     return;
   }

--- a/src/commands/generateTests.ts
+++ b/src/commands/generateTests.ts
@@ -1,12 +1,12 @@
 import * as vscode from "vscode";
-import { FileSearchStrategy, findTestFile, getFileInfo, getFilesExports, getRootDir } from "../utils/file";
+import { FileSearchStrategy, findTestFile, getFileInfo, getFilesExports, getRemixRootFromFileUri } from "../utils/file";
 import { getPathDifference } from "../utils/dependencies";
 import { generateTestFile } from "../generators/test/test.file";
 import { askInstallDependenciesPrompt, commandWithLoading } from "../utils/vscode";
 import { getConfig } from "../config";
 
 export const generateTests = async (uri: vscode.Uri) => {
-  const rootDir = await getRootDir();
+  const rootDir = await getRemixRootFromFileUri(uri);
   if (!rootDir) {
     return;
   }
@@ -34,6 +34,6 @@ export const generateTests = async (uri: vscode.Uri) => {
       vscode.Uri.joinPath(uri, "..", fileNameWithoutExtension + ".test." + fileNameExtension),
       isRouteFile,
     );
-    askInstallDependenciesPrompt([], ["@testing-library/react"]);
+    askInstallDependenciesPrompt(rootDir, [], ["@testing-library/react"]);
   });
 };

--- a/src/commands/generateTests.ts
+++ b/src/commands/generateTests.ts
@@ -1,12 +1,12 @@
 import * as vscode from "vscode";
-import { FileSearchStrategy, findTestFile, getFileInfo, getFilesExports, getRootDirPath } from "../utils/file";
+import { FileSearchStrategy, findTestFile, getFileInfo, getFilesExports, getRootDir } from "../utils/file";
 import { getPathDifference } from "../utils/dependencies";
 import { generateTestFile } from "../generators/test/test.file";
 import { askInstallDependenciesPrompt, commandWithLoading } from "../utils/vscode";
 import { getConfig } from "../config";
 
 export const generateTests = async (uri: vscode.Uri) => {
-  const rootDir = getRootDirPath();
+  const rootDir = await getRootDir();
   if (!rootDir) {
     return;
   }
@@ -32,7 +32,7 @@ export const generateTests = async (uri: vscode.Uri) => {
       exportNames,
       `./${fileNameWithoutExtension}`,
       vscode.Uri.joinPath(uri, "..", fileNameWithoutExtension + ".test." + fileNameExtension),
-      isRouteFile
+      isRouteFile,
     );
     askInstallDependenciesPrompt([], ["@testing-library/react"]);
   });

--- a/src/commands/initShadcnUi.ts
+++ b/src/commands/initShadcnUi.ts
@@ -1,6 +1,5 @@
 import * as vscode from "vscode";
 import {
-  commandWithLoading,
   getPickableOptions,
   getUserInput,
   installDependencies,
@@ -9,7 +8,7 @@ import {
   sanitizePath,
   writeToFile,
 } from "../utils/vscode";
-import { getRootDir, tryReadFile } from "../utils/file";
+import { getDirFromFileUri, tryReadFile } from "../utils/file";
 import { getConfig } from "../config";
 
 const moveUtils = async (rootDir: vscode.Uri, libLocation: string) => {
@@ -22,12 +21,16 @@ const moveUtils = async (rootDir: vscode.Uri, libLocation: string) => {
   if (!newLoc) {
     await vscode.workspace.fs.createDirectory(joinPath(rootDir, sanitizePath(libLocation)));
   }
-  await vscode.workspace.fs.rename(oldLocation, newLocation);
+  try {
+    await vscode.workspace.fs.rename(oldLocation, newLocation);
+  } catch (e) {
+    return;
+  }
   try {
     await vscode.workspace.fs.delete(vscode.Uri.joinPath(rootDir, "@"));
   } catch (err) {
     vscode.window.showErrorMessage(
-      "Failed to delete lib folder on the root due to the extension not having the required permissions to remove the directory. Please delete it manually."
+      "Failed to delete lib folder on the root due to the extension not having the required permissions to remove the directory. Please delete it manually.",
     );
   }
 };
@@ -67,7 +70,7 @@ const updateRoot = async (rootDir: vscode.Uri, cssName: string, runtimeDependenc
               "];",
               "",
               "export default",
-            ].join("\n")
+            ].join("\n"),
           );
       }
       if (
@@ -76,7 +79,9 @@ const updateRoot = async (rootDir: vscode.Uri, cssName: string, runtimeDependenc
       ) {
         rootContent = rootContent.replace(
           "export const links: LinksFunction = () => [",
-          ["export const links: LinksFunction = () => [", '  { rel: "stylesheet", href: styles },', "];", ""].join("\n")
+          ["export const links: LinksFunction = () => [", '  { rel: "stylesheet", href: styles },', "];", ""].join(
+            "\n",
+          ),
         );
       }
 
@@ -111,13 +116,13 @@ const updateTsconfig = async (rootDir: vscode.Uri, libLocation: string) => {
         if (!tsConfigString.includes("@/*") && tsConfigString.includes("paths")) {
           tsConfigString = tsConfigString.replace(
             '"paths": {',
-            [`"paths": {`, `      "@/*": ["${alias}"],`].join("\n")
+            [`"paths": {`, `      "@/*": ["${alias}"],`].join("\n"),
           );
         }
         if (!tsConfigString.includes("paths")) {
           tsConfigString = tsConfigString.replace(
             '"compilerOptions": {',
-            [`"compilerOptions": {`, `    "paths": {`, `      "@/*": ["${alias}"]`, `    },`].join("\n")
+            [`"compilerOptions": {`, `    "paths": {`, `      "@/*": ["${alias}"]`, `    },`].join("\n"),
           );
         }
 
@@ -128,10 +133,7 @@ const updateTsconfig = async (rootDir: vscode.Uri, libLocation: string) => {
 };
 
 export const initShadcnUi = async (uri: vscode.Uri) => {
-  const rootDir = getRootDir();
-  if (!rootDir) {
-    return;
-  }
+  const rootDir = getDirFromFileUri(uri);
   const initialized = await tryReadFile(joinPath(rootDir, "components.json"));
   if (initialized) {
     vscode.window.showErrorMessage("Shadcn UI is already initialized in this project.");
@@ -157,15 +159,11 @@ export const initShadcnUi = async (uri: vscode.Uri) => {
     title: "Initializing shadcn/ui",
     promptHandler: async (process, resolve) => {
       process.stdout?.on("data", (data) => {
-        if (data.toString().includes("Which style would you like to use?") && commands[0].runTimes > 0) {
-          while (commands[0].runTimes > 0) {
-            process.stdin?.write(commands[0].command);
-            commands[0].runTimes = commands[0].runTimes - 1;
-          }
-          process.stdin?.write("\x0D");
+        if (data.toString().includes("Would you like to use TypeScript (recommended)?") && commands[0].runTimes > 0) {
+          process.stdin?.write(commands[0].command);
+          commands[0].runTimes = commands[0].runTimes - 1;
         }
-
-        if (data.toString().includes("Which color would you like to use as base color?") && commands[1].runTimes > 0) {
+        if (data.toString().includes("Which style would you like to use?") && commands[1].runTimes > 0) {
           while (commands[1].runTimes > 0) {
             process.stdin?.write(commands[1].command);
             commands[1].runTimes = commands[1].runTimes - 1;
@@ -173,33 +171,41 @@ export const initShadcnUi = async (uri: vscode.Uri) => {
           process.stdin?.write("\x0D");
         }
 
-        if (data.toString().includes("Where is your global CSS file?") && commands[2].runTimes > 0) {
-          process.stdin?.write(commands[2].command);
-          commands[2].runTimes = commands[2].runTimes - 1;
+        if (data.toString().includes("Which color would you like to use as base color?") && commands[2].runTimes > 0) {
+          while (commands[2].runTimes > 0) {
+            process.stdin?.write(commands[2].command);
+            commands[2].runTimes = commands[2].runTimes - 1;
+          }
+          process.stdin?.write("\x0D");
         }
-        if (data.toString().includes("Do you want to use CSS variables for colors?") && commands[3].runTimes > 0) {
+
+        if (data.toString().includes("Where is your global CSS file?") && commands[3].runTimes > 0) {
           process.stdin?.write(commands[3].command);
           commands[3].runTimes = commands[3].runTimes - 1;
         }
-        if (data.toString().includes("Where is your tailwind.config.js located?") && commands[4].runTimes > 0) {
+        if (data.toString().includes("Would you like to use CSS variables for colors?") && commands[4].runTimes > 0) {
           process.stdin?.write(commands[4].command);
           commands[4].runTimes = commands[4].runTimes - 1;
         }
-        if (data.toString().includes("Configure the import alias for components:") && commands[5].runTimes > 0) {
+        if (data.toString().includes("Where is your tailwind.config.js located?") && commands[5].runTimes > 0) {
           process.stdin?.write(commands[5].command);
           commands[5].runTimes = commands[5].runTimes - 1;
         }
-        if (data.toString().includes("Configure the import alias for utils:") && commands[6].runTimes > 0) {
+        if (data.toString().includes("Configure the import alias for components:") && commands[6].runTimes > 0) {
           process.stdin?.write(commands[6].command);
           commands[6].runTimes = commands[6].runTimes - 1;
         }
-        if (data.toString().includes("Are you using React Server Components?") && commands[7].runTimes > 0) {
+        if (data.toString().includes("Configure the import alias for utils:") && commands[7].runTimes > 0) {
           process.stdin?.write(commands[7].command);
           commands[7].runTimes = commands[7].runTimes - 1;
         }
-        if (data.toString().includes("Write configuration to components.json") && commands[8].runTimes > 0) {
+        if (data.toString().includes("Are you using React Server Components?") && commands[8].runTimes > 0) {
           process.stdin?.write(commands[8].command);
           commands[8].runTimes = commands[8].runTimes - 1;
+        }
+        if (data.toString().includes("Write configuration to components.json") && commands[9].runTimes > 0) {
+          process.stdin?.write(commands[9].command);
+          commands[9].runTimes = commands[9].runTimes - 1;
           process.stdin?.end();
         }
       });
@@ -229,7 +235,7 @@ const generateCLICommands = async (cssName: string) => {
       { picked: true, label: "Default", value: 0 },
       { value: 1, label: "New York" },
     ],
-    { title: "Pick your style options" }
+    { title: "Pick your style options" },
   );
   const colorPick = await getPickableOptions(
     [
@@ -239,7 +245,7 @@ const generateCLICommands = async (cssName: string) => {
       { value: 3, label: "Neutral" },
       { value: 4, label: "Stone" },
     ],
-    { title: "Pick your template colors" }
+    { title: "Pick your template colors" },
   );
 
   const cssVars = await getPickableOptions(
@@ -247,12 +253,13 @@ const generateCLICommands = async (cssName: string) => {
       { picked: true, label: "No", description: "Will not use CSS variables for colors", value: 0 },
       { value: 1, description: "Will use CSS variables for colors", label: "Yes" },
     ],
-    { title: "Do you want to use CSS variables for colors?" }
+    { title: "Would you like to use CSS variables for colors?" },
   );
 
   if (!stylePick || !colorPick || !cssVars) {
     return commands;
   }
+  commands.push({ command: "\x0D", runTimes: 1 });
   commands.push({ command: `\x1B[B`, runTimes: stylePick.value > 0 ? stylePick.value : 1 });
 
   commands.push({ command: `\x1B[B`, runTimes: colorPick.value > 0 ? colorPick.value : 1 });

--- a/src/commands/initShadcnUi.ts
+++ b/src/commands/initShadcnUi.ts
@@ -8,7 +8,7 @@ import {
   sanitizePath,
   writeToFile,
 } from "../utils/vscode";
-import { getDirFromFileUri, tryReadFile } from "../utils/file";
+import { getRemixRootFromFileUri, tryReadFile } from "../utils/file";
 import { getConfig } from "../config";
 
 const moveUtils = async (rootDir: vscode.Uri, libLocation: string) => {
@@ -133,7 +133,10 @@ const updateTsconfig = async (rootDir: vscode.Uri, libLocation: string) => {
 };
 
 export const initShadcnUi = async (uri: vscode.Uri) => {
-  const rootDir = getDirFromFileUri(uri);
+  const rootDir = await getRemixRootFromFileUri(uri);
+  if (!rootDir) {
+    return;
+  }
   const initialized = await tryReadFile(joinPath(rootDir, "components.json"));
   if (initialized) {
     vscode.window.showErrorMessage("Shadcn UI is already initialized in this project.");
@@ -155,6 +158,7 @@ export const initShadcnUi = async (uri: vscode.Uri) => {
     return;
   }
   await runCommandWithPrompt({
+    rootDir,
     command: "npx shadcn-ui@latest init",
     title: "Initializing shadcn/ui",
     promptHandler: async (process, resolve) => {
@@ -218,7 +222,7 @@ export const initShadcnUi = async (uri: vscode.Uri) => {
   await updateTsconfig(rootDir, libLocation);
   await updateRemixConfig(rootDir);
 
-  await installDependencies([
+  await installDependencies(rootDir, [
     "class-variance-authority",
     "clsx",
     " tailwind-merge",

--- a/src/commands/linting.ts
+++ b/src/commands/linting.ts
@@ -1,22 +1,23 @@
 import * as vscode from "vscode";
-import { getRootDir } from "../utils/file";
+import { getRemixRootFromFileUri } from "../utils/file";
 import { extendPackageJsonWithLinting, generateEslintConfig } from "../generators/linting/eslint";
 import { generatePrettierIgnore, generatePrettierRc } from "../generators/linting/prettier";
 import { askInstallDependenciesPrompt } from "../utils/vscode";
 
 export const linting = async (uri: vscode.Uri) => {
-  const path = await getRootDir();
-  if (!path) {
+  const rootDir = await getRemixRootFromFileUri(uri);
+  if (!rootDir) {
     return;
   }
-  await vscode.workspace.fs.writeFile(vscode.Uri.joinPath(path, ".eslintrc"), Buffer.from(generateEslintConfig()));
-  await vscode.workspace.fs.writeFile(vscode.Uri.joinPath(path, ".prettierrc"), Buffer.from(generatePrettierRc()));
+  await vscode.workspace.fs.writeFile(vscode.Uri.joinPath(rootDir, ".eslintrc"), Buffer.from(generateEslintConfig()));
+  await vscode.workspace.fs.writeFile(vscode.Uri.joinPath(rootDir, ".prettierrc"), Buffer.from(generatePrettierRc()));
   await vscode.workspace.fs.writeFile(
-    vscode.Uri.joinPath(path, ".prettierignore"),
+    vscode.Uri.joinPath(rootDir, ".prettierignore"),
     Buffer.from(generatePrettierIgnore()),
   );
-  await extendPackageJsonWithLinting();
+  await extendPackageJsonWithLinting(rootDir);
   askInstallDependenciesPrompt(
+    rootDir,
     [],
     ["@remix-run/eslint-config", "eslint", "eslint-config-prettier", "eslint-plugin-prettier", "prettier"],
   );

--- a/src/commands/linting.ts
+++ b/src/commands/linting.ts
@@ -1,11 +1,11 @@
 import * as vscode from "vscode";
-import { getRootDirPath } from "../utils/file";
+import { getRootDir } from "../utils/file";
 import { extendPackageJsonWithLinting, generateEslintConfig } from "../generators/linting/eslint";
 import { generatePrettierIgnore, generatePrettierRc } from "../generators/linting/prettier";
 import { askInstallDependenciesPrompt } from "../utils/vscode";
 
 export const linting = async (uri: vscode.Uri) => {
-  const path = getRootDirPath();
+  const path = await getRootDir();
   if (!path) {
     return;
   }
@@ -13,11 +13,11 @@ export const linting = async (uri: vscode.Uri) => {
   await vscode.workspace.fs.writeFile(vscode.Uri.joinPath(path, ".prettierrc"), Buffer.from(generatePrettierRc()));
   await vscode.workspace.fs.writeFile(
     vscode.Uri.joinPath(path, ".prettierignore"),
-    Buffer.from(generatePrettierIgnore())
+    Buffer.from(generatePrettierIgnore()),
   );
   await extendPackageJsonWithLinting();
   askInstallDependenciesPrompt(
     [],
-    ["@remix-run/eslint-config", "eslint", "eslint-config-prettier", "eslint-plugin-prettier", "prettier"]
+    ["@remix-run/eslint-config", "eslint", "eslint-config-prettier", "eslint-plugin-prettier", "prettier"],
   );
 };

--- a/src/commands/updateRemix.ts
+++ b/src/commands/updateRemix.ts
@@ -1,15 +1,18 @@
 import * as vscode from "vscode";
 import { runCommand } from "../utils/vscode";
+import { getRemixRootFromFileUri } from "../utils/file";
 
-export const updateRemix = async () => {
+export const updateRemix = async (uri: vscode.Uri) => {
+  const rootDir = await getRemixRootFromFileUri(uri);
   const version = await vscode.window.showInputBox({
     prompt: "Enter the version of Remix you want to update to (latest, nightly, or specific version, eg: 1.17.0)",
     value: "latest",
   });
-  if (!version) {
+  if (!version || !rootDir) {
     return;
   }
   await runCommand({
+    rootDir,
     command: `npx upgrade-remix ${version ? version : ""}`,
     title: "Updating Remix dependencies",
     errorMessage: "Error updating Remix dependencies, you might have provided an invalid version.",

--- a/src/devTools/allRoutes.ts
+++ b/src/devTools/allRoutes.ts
@@ -8,7 +8,7 @@ interface Route {
 }
 
 export const getAllRemixRoutes = async () => {
-  const rootDir = getRootDir();
+  const rootDir = await getRootDir();
   if (!rootDir) {
     return undefined;
   }

--- a/src/devTools/allRoutes.ts
+++ b/src/devTools/allRoutes.ts
@@ -1,4 +1,4 @@
-import { generatePath, getRootDir } from "../utils/file";
+import { generatePath, getRemixRootFromFileUri } from "../utils/file";
 import { joinPath, tryReadDirectory } from "../utils/vscode";
 import * as vscode from "vscode";
 
@@ -7,8 +7,8 @@ interface Route {
   url: string;
 }
 
-export const getAllRemixRoutes = async () => {
-  const rootDir = await getRootDir();
+export const getAllRemixRoutes = async (uri: vscode.Uri) => {
+  const rootDir = await getRemixRootFromFileUri(uri);
   if (!rootDir) {
     return undefined;
   }

--- a/src/devTools/getProjectCommands.ts
+++ b/src/devTools/getProjectCommands.ts
@@ -1,7 +1,8 @@
 import { getPackageJson } from "../utils/vscode";
+import * as vscode from "vscode";
 
-export const getProjectCommands = async () => {
-  const pkg = await getPackageJson();
+export const getProjectCommands = async (uri: vscode.Uri) => {
+  const pkg = await getPackageJson(uri);
   if (!pkg) {
     return undefined;
   }

--- a/src/devTools/killProcess.ts
+++ b/src/devTools/killProcess.ts
@@ -4,19 +4,19 @@ const pidtree = require("pidtree");
 let isWindows = process.platform === "win32";
 
 export const kill = async (pid: number) => {
-  if (!isAlive(pid)) return;
+  if (!isAlive(pid)) {return;}
   if (isWindows) {
     await execa("taskkill", ["/F", "/PID", pid.toString()]).catch((error: any) => {
       // taskkill 128 -> the process is already dead
-      if (error.exitCode === 128) return;
-      if (/There is no running instance of the task./.test(error.message)) return;
+      if (error.exitCode === 128) {return;}
+      if (/There is no running instance of the task./.test(error.message)) {return;}
       console.warn(error.message);
     });
     return;
   }
   await execa("kill", ["-9", pid.toString()]).catch((error: any) => {
     // process is already dead
-    if (/No such process/.test(error.message)) return;
+    if (/No such process/.test(error.message)) {return;}
     console.warn(error.message);
   });
 };

--- a/src/devTools/runTerminalCommands.ts
+++ b/src/devTools/runTerminalCommands.ts
@@ -1,10 +1,11 @@
 import { exec } from "child_process";
-import { getWorkspacePath } from "../utils/vscode";
 import { WebSocket, WebSocketServer } from "ws";
 import { killtree } from "./killProcess";
+import { getRootDir } from "../utils/file";
 /** Make this work properly with the remix dev tools so it executes, closes and runs processes */
-const executeCommand = (command: string, socket: WebSocket, terminalId: number, wss: WebSocketServer) => {
-  const process = exec(command, { cwd: getWorkspacePath(), env: { FORCE_COLOR: "true" } });
+const executeCommand = async (command: string, socket: WebSocket, terminalId: number, wss: WebSocketServer) => {
+  const workspacePath = await getRootDir();
+  const process = exec(command, { cwd: workspacePath?.fsPath, env: { FORCE_COLOR: "true" } });
 
   process.on("spawn", () => {
     socket.send(
@@ -12,7 +13,7 @@ const executeCommand = (command: string, socket: WebSocket, terminalId: number, 
         type: "terminal_command",
         terminalId,
         processId: process.pid,
-      })
+      }),
     );
   });
   process.on("error", (error) => {
@@ -25,7 +26,7 @@ const executeCommand = (command: string, socket: WebSocket, terminalId: number, 
         subtype: "DATA",
         terminalId,
         data: data.toString(),
-      })
+      }),
     );
   });
 
@@ -56,7 +57,7 @@ export const runTerminalCommands = async (
   socket: WebSocket,
   command: string,
   terminalId: number,
-  wss: WebSocketServer
+  wss: WebSocketServer,
 ) => {
-  executeCommand(command, socket, terminalId, wss);
+  await executeCommand(command, socket, terminalId, wss);
 };

--- a/src/devTools/runTerminalCommands.ts
+++ b/src/devTools/runTerminalCommands.ts
@@ -1,10 +1,11 @@
 import { exec } from "child_process";
 import { WebSocket, WebSocketServer } from "ws";
 import { killtree } from "./killProcess";
-import { getRootDir } from "../utils/file";
+import { getRemixRootFromFileUri } from "../utils/file";
+import * as vscode from  'vscode';
 /** Make this work properly with the remix dev tools so it executes, closes and runs processes */
-const executeCommand = async (command: string, socket: WebSocket, terminalId: number, wss: WebSocketServer) => {
-  const workspacePath = await getRootDir();
+const executeCommand = async (uri: vscode.Uri, command: string, socket: WebSocket, terminalId: number, wss: WebSocketServer) => {
+  const workspacePath = await getRemixRootFromFileUri(uri);
   const process = exec(command, { cwd: workspacePath?.fsPath, env: { FORCE_COLOR: "true" } });
 
   process.on("spawn", () => {
@@ -54,10 +55,11 @@ const executeCommand = async (command: string, socket: WebSocket, terminalId: nu
   });
 };
 export const runTerminalCommands = async (
+  uri: vscode.Uri,
   socket: WebSocket,
   command: string,
   terminalId: number,
   wss: WebSocketServer,
 ) => {
-  await executeCommand(command, socket, terminalId, wss);
+  await executeCommand(uri, command, socket, terminalId, wss);
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,10 +20,11 @@ import { ActionLens } from "./code-lenses/ActionLens";
 import { checkRemixVersion } from "./startup/checkRemixVersion";
 import { generateRemixPartial } from "./commands/editorContext";
 import { startDevTools } from "./commands/devTools";
-import { generateCommand } from "./utils/vscode";
+import { generateCommand, getWorkspaceUri } from "./utils/vscode";
 import { createStatusBar } from "./utils/statusBar";
+import { isRemixDir } from "./utils/file";
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
   const flattenRoutesCommand = vscode.commands.registerCommand(generateCommand("flattenRoutes"), flattenRoutes);
   const generateAuthCommand = vscode.commands.registerCommand(generateCommand("generateAuth"), generateAuth);
   const openUrlCommand = vscode.commands.registerCommand(generateCommand("openUrl"), openUrl);
@@ -32,44 +33,44 @@ export function activate(context: vscode.ExtensionContext) {
   const generatePrismaCommand = vscode.commands.registerCommand(generateCommand("generatePrisma"), generatePrisma);
   const generateTestsCommand = vscode.commands.registerCommand(generateCommand("generateTests"), generateTests);
   const generateLoaderCommand = vscode.commands.registerCommand(generateCommand("generateLoader"), () =>
-    generateRemixPartial("loader")
+    generateRemixPartial("loader"),
   );
   const generateActionCommand = vscode.commands.registerCommand(generateCommand("generateAction"), () =>
-    generateRemixPartial("action")
+    generateRemixPartial("action"),
   );
   const generateErrorBoundaryCommand = vscode.commands.registerCommand(generateCommand("generateErrorBoundary"), () =>
-    generateRemixPartial("errorBoundary")
+    generateRemixPartial("errorBoundary"),
   );
   const generateMetaCommand = vscode.commands.registerCommand(generateCommand("generateMeta"), () =>
-    generateRemixPartial("meta")
+    generateRemixPartial("meta"),
   );
   const generateHeadersCommand = vscode.commands.registerCommand(generateCommand("generateHeaders"), () =>
-    generateRemixPartial("headers")
+    generateRemixPartial("headers"),
   );
   const generateLinksCommand = vscode.commands.registerCommand(generateCommand("generateLinks"), () =>
-    generateRemixPartial("links")
+    generateRemixPartial("links"),
   );
   const generateRevalidateCommand = vscode.commands.registerCommand(generateCommand("generateRevalidate"), () =>
-    generateRemixPartial("revalidate")
+    generateRemixPartial("revalidate"),
   );
   const lintingCommand = vscode.commands.registerCommand(generateCommand("linting"), linting);
   const initShadcnUiCommand = vscode.commands.registerCommand(generateCommand("initShadcnUi"), initShadcnUi);
   const generateShadcnUICommand = vscode.commands.registerCommand(
     generateCommand("generateShadcnUI"),
-    generateShadcnUI
+    generateShadcnUI,
   );
 
   const generateRouteFileCommand = vscode.commands.registerCommand(
     generateCommand("generateRemixRoute"),
-    generateRouteFile
+    generateRouteFile,
   );
   const generateRemixFormRouteCommand = vscode.commands.registerCommand(
     generateCommand("generateRemixFormRoute"),
-    generateRemixFormRoute
+    generateRemixFormRoute,
   );
   const generateAuthSnippetCommand = vscode.commands.registerCommand(
     generateCommand("generateAuthSnippet"),
-    generateAuthSnippet
+    generateAuthSnippet,
   );
   const codeLensProvider = new ComponentLens();
   const loaderLens = new LoaderLens();
@@ -77,7 +78,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   const statusBarAddition = createStatusBar();
   const devToolsCommand = vscode.commands.registerCommand(generateCommand("devTools"), () =>
-    startDevTools(statusBarAddition)
+    startDevTools(statusBarAddition),
   );
   // Add the status bar item to the extensions' context
   context.subscriptions.push(statusBarAddition);
@@ -88,7 +89,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.languages.registerCodeLensProvider({ scheme: "file", language: "typescriptreact" }, codeLensProvider),
     vscode.languages.registerCodeLensProvider({ scheme: "file", language: "typescriptreact" }, loaderLens),
-    vscode.languages.registerCodeLensProvider({ scheme: "file", language: "typescriptreact" }, actionLens)
+    vscode.languages.registerCodeLensProvider({ scheme: "file", language: "typescriptreact" }, actionLens),
   );
 
   // Register the commands
@@ -113,10 +114,17 @@ export function activate(context: vscode.ExtensionContext) {
     generateHeadersCommand,
     generateLinksCommand,
     generateRevalidateCommand,
-    devToolsCommand
+    devToolsCommand,
   );
   // Do all the startup checks after this line
-  checkRemixVersion();
+  const workspaceUri = getWorkspaceUri();
+  if (!workspaceUri) {
+    return;
+  }
+  if (!(await isRemixDir(workspaceUri))) {
+    return;
+  }
+  checkRemixVersion(workspaceUri);
 }
 
 export function deactivate() {}

--- a/src/generators/dependencies.ts
+++ b/src/generators/dependencies.ts
@@ -23,7 +23,7 @@ export const generateDependencies = (
   }
   if (selectedGenerators.includes("loader")) {
     remixDeps.push("LoaderFunctionArgs");
-    if (shouldIncludeLoaderData) reactDeps.push("useLoaderData");
+    if (shouldIncludeLoaderData) {reactDeps.push("useLoaderData");}
   }
   if (selectedGenerators.includes("action")) {
     remixDeps.push("ActionFunctionArgs");

--- a/src/generators/linting/eslint.ts
+++ b/src/generators/linting/eslint.ts
@@ -13,10 +13,8 @@ export const generateEslintConfig = () => {
   ].join("\n");
 };
 
-export const extendPackageJsonWithLinting = async () => {
-  const pkg = await getPackageJson();
-  const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri;
-  if (!workspaceRoot) {return;}
+export const extendPackageJsonWithLinting = async (rootDir: vscode.Uri) => {
+  const pkg = await getPackageJson(rootDir);
 
   if (!pkg.scripts.lint) {
     pkg.scripts.lint = `eslint \"app/**/*.+(ts|tsx)\"`;
@@ -35,7 +33,7 @@ export const extendPackageJsonWithLinting = async () => {
   }
 
   await vscode.workspace.fs.writeFile(
-    vscode.Uri.joinPath(workspaceRoot, "package.json"),
-    Buffer.from(JSON.stringify(pkg, null, 2))
+    vscode.Uri.joinPath(rootDir, "package.json"),
+    Buffer.from(JSON.stringify(pkg, null, 2)),
   );
 };

--- a/src/generators/linting/eslint.ts
+++ b/src/generators/linting/eslint.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { getPackageJson, getWorkspacePath } from "../../utils/vscode";
+import { getPackageJson } from "../../utils/vscode";
 
 export const generateEslintConfig = () => {
   return [
@@ -16,7 +16,7 @@ export const generateEslintConfig = () => {
 export const extendPackageJsonWithLinting = async () => {
   const pkg = await getPackageJson();
   const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri;
-  if (!workspaceRoot) return;
+  if (!workspaceRoot) {return;}
 
   if (!pkg.scripts.lint) {
     pkg.scripts.lint = `eslint \"app/**/*.+(ts|tsx)\"`;

--- a/src/startup/checkRemixVersion.ts
+++ b/src/startup/checkRemixVersion.ts
@@ -1,8 +1,9 @@
 import { exec } from "child_process";
-import { getPackageJson, getWorkspacePath } from "../utils/vscode";
+import { getPackageJson } from "../utils/vscode";
 import { updateRemix } from "../commands";
 import * as vscode from "vscode";
 import { getConfig } from "../config";
+import { getRootDir } from "../utils/file";
 
 export const checkRemixVersion = async () => {
   const config = getConfig();
@@ -26,7 +27,8 @@ export const checkRemixVersion = async () => {
   }
 
   const promise = new Promise<string | undefined>(async (resolve) => {
-    exec(`npm view @remix-run/react version`, { cwd: getWorkspacePath() }, (error, stdout, stderr) => {
+    const rootDir = await getRootDir();
+    exec(`npm view @remix-run/react version`, { cwd: rootDir?.fsPath }, (error, stdout, stderr) => {
       if (error) {
         return resolve(undefined);
       }
@@ -48,10 +50,10 @@ export const checkRemixVersion = async () => {
     .showInformationMessage(
       `Your Remix version is ${remixVersion.replace(
         "^",
-        ""
+        "",
       )}, but the latest version is ${version}. Do you want to update?`,
       "Yes",
-      "No"
+      "No",
     )
     .then((value) => {
       if (value === "Yes") {


### PR DESCRIPTION
At first, thank you for great extension.

I fixed #3 and #16.

I have done as much testing as possible, but I have concerns regarding the following points related to the changes:

- The distinction between getRootDirPath, getRootDir, and getWorkSpacePath
  - I couldn't infer the intention behind differentiating these functions. As far as I could tell, they probably yield the same result, so I standardized to getRootDir. However, I cannot guarantee that it's functioning as intended.
- I recently discovered this extension, so I'm not sure if it's correct that the @ directory remains after running `Initialize shadcn-ui in your project`
- This is unrelated to the issue, but there are parts in the changes where the formatting has been altered. (For example, commas that weren't there before have been added.) 
  - However, this is due to running eslint --fix.

I apologize, the commits became a bit sloppy because I did this for myself. If you'd prefer separate commits and PRs for each issue, I can resubmit them that way.